### PR TITLE
Fix for the Isssue #1 I created : only 1 params in query were asked to the forecast.io api.

### DIFF
--- a/wp-forecast-io.php
+++ b/wp-forecast-io.php
@@ -170,7 +170,7 @@ class Forecast {
 	 */
 	private function request() {
 		
-		$response = wp_remote_get( esc_url( $this->request_url ) );
+		$response = wp_remote_get( $this->request_url );
 		try {
 			$json = json_decode( wp_remote_retrieve_body( $response ), true );
 		} catch ( Exception $ex ) {

--- a/wp-forecast-io.php
+++ b/wp-forecast-io.php
@@ -170,7 +170,7 @@ class Forecast {
 	 */
 	private function request() {
 		
-		$response = wp_remote_get( $this->request_url );
+		$response = wp_remote_get( esc_url($this->request_url, 'https', 'api') );
 		try {
 			$json = json_decode( wp_remote_retrieve_body( $response ), true );
 		} catch ( Exception $ex ) {


### PR DESCRIPTION
This way, the url keep all the other params passed after the first &.
