### PR TITLE
Update cache_time default to integer

### DIFF
--- a/wp-forecast-io.php
+++ b/wp-forecast-io.php
@@ -45,7 +45,7 @@ class Forecast {
 		'time'		=> null, // Time in seconds
 		'cache_prefix'	=> 'api_', // careful here, md5 is used on the request url to generate the transient name. You are limited to an 8 character prefix before the combined total exceeds the transient name limit
 		'cache_enabled'	=> true,
-		'cache_time'	=> (6 * HOUR_IN_SECONDS), // Time in seconds
+		'cache_time'	=> 21600, // Time in seconds, defaults to 6 hours
 		'clear_cache'	=> false, // set to true to force the cache to clear
 		'query'		=> array(),
 	);


### PR DESCRIPTION
Expressions aren't parsed in php prior to v5.6, provides backwards compatibility. Thanks to @sprclldr for the catch. Closes #3.
