### PR TITLE
Correct $transient_name variable in set_transient

### DIFF
--- a/wp-forecast-io.php
+++ b/wp-forecast-io.php
@@ -58,13 +58,6 @@ class Forecast {
 	public $request_url;
 	
 	/**
-	 * The hashed transient name.
-	 *
-	 * @since 1.0.0
-	 */
-	private $transient_name;
-
-	/**
 	 * The stored response.
 	 * 
 	 * @since 1.0.0

--- a/wp-forecast-io.php
+++ b/wp-forecast-io.php
@@ -140,7 +140,7 @@ class Forecast {
 				$response = $this->request();
 				
 				if( $response )
-					set_transient( $this->transient_name, $response, $this->cache_time );
+					set_transient( $transient_name, $response, $this->cache_time );
 				
 			} else {
 				$response = $transient;

--- a/wp-forecast-io.php
+++ b/wp-forecast-io.php
@@ -58,6 +58,13 @@ class Forecast {
 	public $request_url;
 	
 	/**
+	 * The hashed transient name.
+	 *
+	 * @since 1.0.0
+	 */
+	private $transient_name;
+
+	/**
 	 * The stored response.
 	 * 
 	 * @since 1.0.0


### PR DESCRIPTION
I could only get the transient to store and retrieve correctly with its hashed name by declaring the $transient_name variable. Considering my previous issue, this could also be a PHP 5.5 issue.
