### PR TITLE
Fix Issue 10 - Units query ignored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 #### 1.1.1 - 07/17/2017 - Fix Issue Causing Query To Be Ignored
-Expanded the code for checking the query array and query string separately. Previous condensed version was causing the HTTP query parameters to be ommitted in the final API Request URL.
+Per #10: Expanded the code for checking the query array and query string separately. The previous condensed version was causing the HTTP query parameters to be omitted in the final API Request URL.
 
 #### 1.1.0 - 01/04/2017 - Change to Dark Sky API
 Updated for Dark Sky API.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+#### 1.1.1 - 07/17/2017 - Fix Issue Causing Query To Be Ignored
+Expanded the code for checking the query array and query string separately. Previous condensed version was causing the HTTP query parameters to be ommitted in the final API Request URL.
+
 #### 1.1.0 - 01/04/2017 - Change to Dark Sky API
 Updated for Dark Sky API.
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ A helper class for using darksky.net in WordPress. Requires a latitude, longitud
 
 See more about the API in the [Dark Sky API Documentation](https://darksky.net/dev/docs).
 
-**Current Version:** 1.1.0
+**Current Version:** 1.1.1
 
 **Minimum PHP:** PHP 5.3.0
 

--- a/wp-darksky.php
+++ b/wp-darksky.php
@@ -40,15 +40,15 @@ class Forecast {
 	 * @since 1.0.0
 	 */
 	private $defaults = array(
-		'api_key'	=> null,
-		'latitude'	=> null,
-		'longitude'	=> null,
-		'time'		=> null, // Time in seconds
+		'api_key'		=> null,
+		'latitude'		=> null,
+		'longitude'		=> null,
+		'time'			=> null, // Time in seconds
 		'cache_prefix'	=> 'api_', // careful here, md5 is used on the request url to generate the transient name. You are limited to an 8 character prefix before the combined total exceeds the transient name limit
 		'cache_enabled'	=> true,
 		'cache_time'	=> 21600, // Time in seconds, defaults to 6 hours
 		'clear_cache'	=> false, // set to true to force the cache to clear
-		'query'		=> array(),
+		'query'			=> array(),
 	);
 	
 	/**

--- a/wp-darksky.php
+++ b/wp-darksky.php
@@ -8,7 +8,7 @@
  * 
  * @link https://github.com/joshuadavidnelson/wp-darksky
  *
- * @version 1.1.0
+ * @version 1.1.1
  *
  * @author Joshua David Nelson, josh@joshuadnelson.com
  * 

--- a/wp-darksky.php
+++ b/wp-darksky.php
@@ -85,8 +85,11 @@ class Forecast {
 		$args = wp_array_slice_assoc( $args, $limit_keys );
 		$this->args = wp_parse_args( $args, $this->defaults );
 		
-		// Build the query arguments for the forecast url
-		$query = ( !empty( $this->query ) && is_array( $this->query ) ) ? '?'. http_build_query( $this->query ) : '';
+		// Build the query string for the forecast url
+		$query_string = is_array( $this->query ) ? http_build_query( $this->query ) : '';
+		
+		// if we have a query string, set it up for the url
+		$query = !empty( $query_string ) ? '?' .$query_string : '';
 		
 		// Build the request url
 		$this->request_url = self::API_ENDPOINT . esc_attr( $this->api_key ) . '/' . floatval( $this->latitude ) . ',' . floatval( $this->longitude ) . ( ( is_null( $this->time ) ) ? '' : ','. $this->time ) . $query;


### PR DESCRIPTION
Expanded the code for checking the query array and query string separately. The previous condensed version was causing the HTTP query parameters to be omitted in the final API Request URL. Addresses #10. Props to @dotherightthing for pointing it out.

Closes #10.